### PR TITLE
Update doc.  Make swift-atomics compile in Playgrounds

### DIFF
--- a/Documentation/Bibliography.md
+++ b/Documentation/Bibliography.md
@@ -1,11 +1,10 @@
-### Functional Programming
+### Functional Programming Reference
 
 https://youtu.be/T5oB8PZQNvY
 
 https://leanpub.com/sofp
 
 ### Swift's Structure Concurrency
-
 [SE-304 Structured Concurrency](https://github.com/apple/swift-evolution/blob/main/proposals/0304-structured-concurrency.md#structured-concurrency-1) The original structured concurrency proposal from Apple.
 
 [Sources for a lot of the design](https://forums.swift.org/t/concurrency-designs-from-other-communities/32389/16)
@@ -60,6 +59,6 @@ https://github.com/bitemyapp/papers/blob/master/Stream%20Fusion%20on%20Haskell%2
 [Resource Acquisition is Initialization](https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization)
 
 ### Odds and Ends
-
+[Actor-isolation and Executors](https://github.com/apple/swift-evolution/blob/main/proposals/0338-clarify-execution-non-actor-async.md)
 [EventLoopPromise](https://github.com/apple/swift-nio/blob/e2c7fa4d4bda7cb7f4150b6a0bd69be2a54ef8c4/Sources/NIOCore/EventLoopFuture.swift#L159)
 [EventLoopFuture deinit](https://github.com/apple/swift-nio/blob/e2c7fa4d4bda7cb7f4150b6a0bd69be2a54ef8c4/Sources/NIOCore/EventLoopFuture.swift#L428)

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
+      "location" : "https://github.com/CSCIX65G/swift-atomics.git",
       "state" : {
-        "revision" : "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
-        "version" : "1.0.2"
+        "branch" : "CSCIX65G/playgrounds",
+        "revision" : "3024f7a375583fea45220d39ed1700fb835d4154"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -24,14 +24,15 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-atomics.git", .upToNextMajor(from: "1.0.2")),
+        .package(url: "https://github.com/CSCIX65G/swift-atomics.git", branch: "CSCIX65G/playgrounds"),
     ],
     targets: [
         .target(
             name: "FreeCombine",
             dependencies: [
                 .product(name: "Atomics", package: "swift-atomics")
-            ]
+            ],
+            cSettings: [.define("DISABLE_SWIFT_RETAINRELEASE")]
         ),
         .testTarget(
             name: "FreeCombineTests",

--- a/Playgrounds/05 - FreeCombine.playground/Pages/00a-Introduction (Examples).xcplaygroundpage/Contents.swift
+++ b/Playgrounds/05 - FreeCombine.playground/Pages/00a-Introduction (Examples).xcplaygroundpage/Contents.swift
@@ -1,4 +1,3 @@
-
 /*:
  # Introduction
 
@@ -27,8 +26,6 @@
  observe how the zip blocks of value `Int(14)` and `String("hello, combined world!")` are all emitted at the very end.
  */
 import Combine
-
-
 func combineVersion() {
     let subject1 = Combine.PassthroughSubject<Int, Error>()
     let subject2 = Combine.PassthroughSubject<String, Error>()
@@ -46,7 +43,7 @@ func combineVersion() {
     
     let m2 = z1.merge(with: m1)
     let cancellable = m2.sink { value in
-        print("received: \(value)")
+        print("Combine received: \(value)")
     }
     
     subject1.send(14)
@@ -59,17 +56,16 @@ combineVersion()
 print("=========================================================")
 
 /*:
- Here's the same example done using FreeCombine.  It's the same algorithm as the combineVersion,
- observe how the zip does not block at all and value `Int(14)` and `String("hello, combined world!")`
- are emitted randomly as they occur.
+ Here's the same example done using FreeCombine.  It's the same algorithm
+ as the combineVersion, observe how the zip does not block at all and value
+ `Int(14)` and `String("hello, combined world!")` are emitted randomly as they occur.
  */
 import FreeCombine
 import _Concurrency
-
 func freeCombineVersion() {
     Task {
-        let subject1 = try await PassthroughSubject(Int.self)
-        let subject2 = try await PassthroughSubject(String.self)
+        let subject1 = try await FreeCombine.PassthroughSubject(Int.self)
+        let subject2 = try await FreeCombine.PassthroughSubject(String.self)
         
         let seq1 = "abcdefghijklmnopqrstuvwxyz".asyncPublisher
         let seq2 = (1 ... 100).asyncPublisher
@@ -86,7 +82,7 @@ func freeCombineVersion() {
         let m2 = z1.merge(with: m1)
         let cancellable = await m2.sink { value in
             guard case let .value(value) = value else { return .more }
-            print("received: \(value)")
+            print("FreeCombine received: \(value)")
             return .more
         }
         
@@ -94,12 +90,10 @@ func freeCombineVersion() {
         try await subject2.send("hello, combined world!")
         try await subject1.finish()
         try await subject2.finish()
-        let finalDemand = try await cancellable.value
-        print(finalDemand)
+        _ = await cancellable.result
     }
 }
 freeCombineVersion()
-print("=========================================================")
 
 /*:
  ## Project Requirements


### PR DESCRIPTION
FIXME:  This MUST be updated to allow full functionality of swift-atomics.  This commit disables DoubleWide on all platforms.  A better way is find a way to improve linking in playgrounds.